### PR TITLE
fix :bug: Fix bug on "gate" in gate names

### DIFF
--- a/include/backend/dd/DDSimDebug.hpp
+++ b/include/backend/dd/DDSimDebug.hpp
@@ -46,6 +46,7 @@ struct DDSimulationState {
   std::vector<InstructionType> instructionTypes;
   std::vector<size_t> instructionStarts;
   std::vector<size_t> instructionEnds;
+  std::set<size_t> functionDefinitions;
   std::map<size_t, std::unique_ptr<Assertion>> assertionInstructions;
   std::map<size_t, size_t> successorInstructions;
   std::vector<QubitRegisterDefinition> qubitRegisters;

--- a/include/common/parsing/CodePreprocessing.hpp
+++ b/include/common/parsing/CodePreprocessing.hpp
@@ -28,6 +28,7 @@ struct Instruction {
   bool isFunctionCall;
   std::string calledFunction;
   bool inFunctionDefinition;
+  bool isFunctionDefition;
 
   std::map<std::string, std::string> callSubstitution;
 
@@ -39,7 +40,8 @@ struct Instruction {
               std::unique_ptr<Assertion>& inputAssertion,
               std::set<std::string> inputTargets, size_t startPos,
               size_t endPos, size_t successor, bool isFuncCall,
-              std::string function, bool inFuncDef, Block inputBlock);
+              std::string function, bool inFuncDef, bool isFuncDef,
+              Block inputBlock);
 };
 
 struct FunctionDefinition {

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -103,3 +103,14 @@ TEST_F(CustomCodeTest, DependenciesWithJumps) {
            "\n"
            "barrier q[2];");
 }
+
+TEST_F(CustomCodeTest, GateInGateName) {
+  loadCode(1, 1,
+           "gate my_gate q0 {"
+           "  x q0;"
+           "}"
+           "my_gate q[0];"
+           "measure q[0] -> c[0];"
+           "assert-eq q[0] { 0, 1 }");
+  state->runSimulation(state);
+}

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -87,23 +87,6 @@ TEST_F(CustomCodeTest, ResetGate) {
   ASSERT_TRUE(complexEquality(result, -1.0, 0.0));
 }
 
-TEST_F(CustomCodeTest, DependenciesWithJumps) {
-  loadCode(3, 1,
-           "gate entangle q0, q1, q2 {\n"
-           "  cx q0, q1;\n"
-           "  cx q0, q2;\n"
-           "  barrier q2;\n"
-           "}\n"
-           "\n"
-           "h q[0];\n"
-           "\n"
-           "entangle q[0], q[1], q[2];\n"
-           "\n"
-           "h q[2];\n"
-           "\n"
-           "barrier q[2];");
-}
-
 TEST_F(CustomCodeTest, GateInGateName) {
   loadCode(1, 1,
            "gate my_gate q0 {"


### PR DESCRIPTION
## Description

Previously, the debugger checked whether an instruction is a custom gate definition by testing if its text contains "gate ". Of course, this could fail if a custom gate or a register name ends with "gate".

With this pull request, we now store a set of custom gate definitions instead. Now, only the CodePreprocessor has to check for the "gate" keyword, and in this step, we have access to the tokenized code, so when we encounter the "gate" token, we can be sure it is actually a custom gate.  

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
