### PR TITLE
fix: :bug: Fix the Substate Vector Problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,5 +52,5 @@ endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in
                ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake IMMEDIATE @ONLY)
-add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P
-                                    ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+add_custom_target(uninstall-debug COMMAND ${CMAKE_COMMAND} -P
+                                          ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -17,6 +17,7 @@ if(BUILD_MQT_DEBUG_BINDINGS)
   find_package(pybind11 2.13 CONFIG REQUIRED)
 endif()
 
+# ---------------------------------------------------------------------------------Fetch MQT Core
 # cmake-format: off
 set(MQT_CORE_VERSION 2.5.2
         CACHE STRING "MQT Core version")
@@ -26,6 +27,7 @@ set(MQT_CORE_REPO_OWNER "cda-tum"
         CACHE STRING "MQT Core repository owner (change when using a fork)")
 # cmake-format: on
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+  # Fetch MQT Core
   FetchContent_Declare(
     mqt-core
     GIT_REPOSITORY https://github.com/${MQT_CORE_REPO_OWNER}/mqt-core.git
@@ -39,6 +41,43 @@ else()
       GIT_REPOSITORY https://github.com/${MQT_CORE_REPO_OWNER}/mqt-core.git
       GIT_TAG ${MQT_CORE_REV})
     list(APPEND FETCH_PACKAGES mqt-core)
+  endif()
+endif()
+
+# ---------------------------------------------------------------------------------Fetch Eigen3
+# cmake-format: off
+set(EIGEN_VERSION 3.4.0
+        CACHE STRING "Eigen3 version")
+# cmake-format: on
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+  # Fetch Eigen3
+  FetchContent_Declare(
+    Eigen3
+    GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+    GIT_TAG ${EIGEN_VERSION}
+    GIT_SHALLOW TRUE)
+  list(APPEND FETCH_PACKAGES Eigen3)
+  set(EIGEN_BUILD_TESTING
+      OFF
+      CACHE BOOL "Disable testing for Eigen")
+  set(EIGEN_BUILD_DOC
+      OFF
+      CACHE BOOL "Disable documentation build for Eigen")
+else()
+  find_package(Eigen3 ${EIGEN3_VERSION} REQUIRED NO_MODULE)
+  if(NOT Eigen3_FOUND)
+    FetchContent_Declare(
+      Eigen3
+      GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+      GIT_TAG ${EIGEN3_VERSION}
+      GIT_SHALLOW TRUE)
+    list(APPEND FETCH_PACKAGES Eigen3)
+    set(EIGEN_BUILD_TESTING
+        OFF
+        CACHE BOOL "Disable testing for Eigen")
+    set(EIGEN_BUILD_DOC
+        OFF
+        CACHE BOOL "Disable documentation build for Eigen")
   endif()
 endif()
 

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -60,6 +60,9 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
   set(EIGEN_BUILD_TESTING
       OFF
       CACHE BOOL "Disable testing for Eigen")
+  set(BUILD_TESTING
+      OFF
+      CACHE BOOL "Disable general testing")
   set(EIGEN_BUILD_DOC
       OFF
       CACHE BOOL "Disable documentation build for Eigen")
@@ -75,6 +78,9 @@ else()
     set(EIGEN_BUILD_TESTING
         OFF
         CACHE BOOL "Disable testing for Eigen")
+    set(BUILD_TESTING
+        OFF
+        CACHE BOOL "Disable general testing")
     set(EIGEN_BUILD_DOC
         OFF
         CACHE BOOL "Disable documentation build for Eigen")

--- a/include/backend/dd/DDSimDebug.hpp
+++ b/include/backend/dd/DDSimDebug.hpp
@@ -127,3 +127,8 @@ bool checkAssertion(DDSimulationState* ddsim,
                     std::unique_ptr<Assertion>& assertion);
 std::string getClassicalBitName(DDSimulationState* ddsim, size_t index);
 size_t variableToQubit(DDSimulationState* ddsim, const std::string& variable);
+bool isSubStateVectorLegal(const Statevector& full,
+                           std::vector<size_t>& targetQubits);
+std::vector<std::vector<Complex>>
+getPartialTraceFromStateVector(const Statevector& sv,
+                               const std::vector<size_t>& traceOut);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include
 # link to the MQT::Core libraries
 target_link_libraries(${PROJECT_NAME} PUBLIC MQT::CoreDD MQT::CoreIR MQT::CoreCircuitOptimizer)
 target_link_libraries(${PROJECT_NAME} PRIVATE MQT::ProjectWarnings MQT::ProjectOptions)
+target_link_libraries(${PROJECT_NAME} PRIVATE Eigen3::Eigen)
 
 # add MQT alias
 add_library(MQT::Debug ALIAS ${PROJECT_NAME})

--- a/src/backend/dd/DDSimDebug.cpp
+++ b/src/backend/dd/DDSimDebug.cpp
@@ -1,7 +1,6 @@
 #include "backend/dd/DDSimDebug.hpp"
 
 #include "Definitions.hpp"
-#include "Eigen/src/Core/Matrix.h"
 #include "backend/dd/DDSimDiagnostics.hpp"
 #include "backend/debug.h"
 #include "backend/diagnostics.h"
@@ -690,7 +689,7 @@ Result ddsimGetStateVectorFull(SimulationState* self, Statevector* output) {
   return OK;
 }
 
-Eigen::MatrixXcd
+Eigen::MatrixXcd // NOLINT
 toEigenMatrix(const std::vector<std::vector<Complex>>& matrix) {
   Eigen::MatrixXcd mat(static_cast<int64_t>(matrix.size()),  // NOLINT
                        static_cast<int64_t>(matrix.size())); // NOLINT

--- a/test/python/resources/bindings/jumps.qasm
+++ b/test/python/resources/bindings/jumps.qasm
@@ -23,10 +23,11 @@ gate create_ghz q0, q1, q2 {
 
 create_ghz q[0], q[1], q[2];
 
-assert-eq q[0], q[1] {
-    qreg q[2];
+assert-eq q[0], q[1], q[2] {
+    qreg q[3];
     h q[0];
     cx q[0], q[1];
+    cx q[0], q[2];
 }
 
-assert-eq 0.9, q[0] { 0.7, 0.7 }
+assert-eq 0.9, q[0], q[1], q[2] { 0.7, 0, 0, 0, 0, 0, 0, 0.7 }

--- a/test/python/test_python_bindings.py
+++ b/test/python/test_python_bindings.py
@@ -209,15 +209,15 @@ def test_access_state(simulation_instance_jumps: SimulationInstance) -> None:
     assert abs(c.imaginary) < 1e-6
     assert abs(c.real) < 1e-6
 
-    sv = simulation_state.get_state_vector_sub([0, 2])
-    assert sv.num_qubits == 2
-    assert sv.num_states == 4
-    c = sv.amplitudes[3]
-    assert abs(c.imaginary) < 1e-6
-    assert abs(c.real - 1 / (2**0.5)) < 1e-6
-    c = sv.amplitudes[2]
-    assert abs(c.imaginary) < 1e-6
-    assert abs(c.real) < 1e-6
+
+def test_get_state_vector_sub(simulation_instance_classical: SimulationInstance) -> None:
+    """Tests the `get_state_vector_sub()` method."""
+    (simulation_state, _state_id) = simulation_instance_classical
+    simulation_state.set_breakpoint(170)
+    simulation_state.run_simulation()
+    assert simulation_state.get_current_instruction() == 10
+    sv = simulation_state.get_state_vector_sub([0, 1])
+    assert sv.amplitudes[0].real == 1 or sv.amplitudes[-1].real == 1
 
 
 def test_classical_get(simulation_instance_classical: SimulationInstance) -> None:

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -108,3 +108,16 @@ TEST_F(CustomCodeTest, EqualityAssertion) {
   ASSERT_EQ(state->runAll(state, &numErrors), OK);
   ASSERT_EQ(numErrors, 0);
 }
+
+TEST_F(CustomCodeTest, DestructiveInterference) {
+  loadCode(3, 0,
+           "x q[0];"
+           "h q[0];"
+           "h q[1];"
+           "cx q[1], q[2];"
+           "assert-sup q[1], q[2];"
+           "assert-ent q[1], q[2];");
+  size_t numErrors = 0;
+  ASSERT_EQ(state->runAll(state, &numErrors), OK);
+  ASSERT_EQ(numErrors, 0);
+}

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -121,3 +121,49 @@ TEST_F(CustomCodeTest, DestructiveInterference) {
   ASSERT_EQ(state->runAll(state, &numErrors), OK);
   ASSERT_EQ(numErrors, 0);
 }
+
+TEST_F(CustomCodeTest, IllegalSubstateSVEqualityAssertion) {
+  loadCode(3, 0,
+           "x q[0];"
+           "h q[0];"
+           "h q[1];"
+           "cx q[1], q[2];"
+           "assert-eq 0.9, q[0], q[1] { 0.5, 0.5, 0.5, 0.5 }");
+  size_t numErrors = 0;
+  ASSERT_EQ(state->runAll(state, &numErrors), ERROR);
+}
+
+TEST_F(CustomCodeTest, LegalSubstateSVEqualityAssertion) {
+  loadCode(3, 0,
+           "x q[0];"
+           "h q[0];"
+           "h q[1];"
+           "cx q[1], q[2];"
+           "assert-eq 0.9, q[1], q[2] { 0.707, 0, 0, 0.707 }");
+  size_t numErrors = 0;
+  ASSERT_EQ(state->runAll(state, &numErrors), OK);
+  ASSERT_EQ(numErrors, 0);
+}
+
+TEST_F(CustomCodeTest, IllegalSubstateCircuitEqualityAssertion) {
+  loadCode(3, 0,
+           "x q[0];"
+           "h q[0];"
+           "h q[1];"
+           "cx q[1], q[2];"
+           "assert-eq 0.9, q[0], q[1] { qreg q[2]; h q[0]; h q[1]; }");
+  size_t numErrors = 0;
+  ASSERT_EQ(state->runAll(state, &numErrors), ERROR);
+}
+
+TEST_F(CustomCodeTest, LegalSubstateCircuitEqualityAssertion) {
+  loadCode(3, 0,
+           "x q[0];"
+           "h q[0];"
+           "h q[1];"
+           "cx q[1], q[2];"
+           "assert-eq 0.9, q[2], q[1] { qreg q[2]; h q[0]; cx q[0], q[1]; }");
+  size_t numErrors = 0;
+  ASSERT_EQ(state->runAll(state, &numErrors), OK);
+  ASSERT_EQ(numErrors, 0);
+}

--- a/test/test_data_retrieval.cpp
+++ b/test/test_data_retrieval.cpp
@@ -169,7 +169,7 @@ TEST_F(DataRetrievalTest, GetStateVectorSub) {
   qubits[0] = 1;
   ASSERT_EQ(state->getStateVectorSub(state, 2, qubits.data(), &sv), OK);
   ASSERT_TRUE(complexEquality(amplitudes[0], 0.0, 0.0));
-  ASSERT_TRUE(complexEquality(amplitudes[1], 0.0,
+  ASSERT_TRUE(complexEquality(amplitudes[1], 1.0,
                               0.0)); // 0 because of destructive interference
   ASSERT_TRUE(complexEquality(amplitudes[2], 0.0, 0.0));
   ASSERT_TRUE(complexEquality(amplitudes[3], 0.0, 0.0));


### PR DESCRIPTION
## Description

This pull request resolves the currently biggest underlying issue: The generation of substate vectors. At the moment, substate vectors are computed by projecting the full state vector onto a subset of its qubits. While this is a valid approach in general, the resulting vector is not guaranteed to be a valid state vector. Due to destructive interference, it may not be normalised or a 0-vector, which is not compatible with many use cases.

Furthermore, all assertion types are currently implemented using substate vectors. For instance, for the superposition assertion, we first compute a substate vector containing only the target qubits and then we perform our calculation. Because of that, this bug spreads over a large part of the code base.

To resolve this, this pull request brings the following changes:
- Substate vectors are revised: Now, instead, we compute the density matrix, trace out unwanted qubits, and then transform back into a state vector. This only works, if the qubits to trace out were not entangled with the other qubits. In other cases, this will throw an exception (and return ERROR)
- Superposition assertion checks are updated: Now, instead of first computing the substate vector, we just take all amplitudes into account. Computationally, this is not more complex than the previous approach, as before, the substate vector computation also checked all amplitudes. By no longer using substate vectors, we can still use this assertion, even if one of the target qubits is entangled with a non-target qubit.
- Entanglement checks are updated: The concept of "is qubit X entangled with qubit Y" is more involved than the previous implementation. Previously, we computed the substate vector of only target qubits and then checked all individual pairs of qubits for entanglement. But now, this would no longer work if a target qubit is entangled with a non-target qubit. Furthermore, the entire previous approach does not work in the presence of entanglement. Therefore, we now use the metric of "mutual information" to check for entanglement. For each pair of target qubits, we first compute our density matrix and trace out all other qubits. This new density matrix is not necessarily pure. We then generate two more density matrices by tracing out each of the remaining qubits, respectively. Using the entropy of these three density matrices, we can then compute the mutual information, which is 0 if and only if the qubits were not entangled. Tests so far seem to suggest that this metric is valid.

Fixes # (issue)

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
