### PR TITLE
:sparkles: Support Register Arguments in Assertions

### DIFF
--- a/include/common/parsing/AssertionParsing.hpp
+++ b/include/common/parsing/AssertionParsing.hpp
@@ -23,6 +23,8 @@ public:
   [[nodiscard]] AssertionType getType() const;
   [[nodiscard]] const std::vector<std::string>& getTargetQubits() const;
   virtual ~Assertion() = default;
+  void setTargetQubits(std::vector<std::string> newTargetQubits);
+  virtual void validate() {};
 };
 
 class EntanglementAssertion : public Assertion {
@@ -42,6 +44,7 @@ public:
   EqualityAssertion(double similarityThreshold,
                     std::vector<std::string> targetQubits, AssertionType type);
   [[nodiscard]] double getSimilarityThreshold() const;
+  void validate() override;
 };
 
 class StatevectorEqualityAssertion : public EqualityAssertion {
@@ -54,6 +57,7 @@ public:
   [[nodiscard]] const Statevector& getTargetStatevector() const;
 
   ~StatevectorEqualityAssertion() override;
+  void validate() override;
 };
 
 class CircuitEqualityAssertion : public EqualityAssertion {

--- a/include/common/parsing/CodePreprocessing.hpp
+++ b/include/common/parsing/CodePreprocessing.hpp
@@ -51,6 +51,10 @@ struct FunctionDefinition {
 
 std::vector<Instruction> preprocessCode(const std::string& code,
                                         std::string& processedCode);
-std::vector<Instruction> preprocessCode(
-    const std::string& code, size_t startIndex, size_t initialCodeOffset,
-    const std::vector<std::string>& functionNames, std::string& processedCode);
+std::vector<Instruction>
+preprocessCode(const std::string& code, size_t startIndex,
+               size_t initialCodeOffset,
+               const std::vector<std::string>& functionNames,
+               std::map<std::string, size_t>& definedRegisters,
+               const std::vector<std::string>& shadowedRegisters,
+               std::string& processedCode);

--- a/src/common/parsing/AssertionParsing.cpp
+++ b/src/common/parsing/AssertionParsing.cpp
@@ -23,6 +23,10 @@ const std::vector<std::string>& Assertion::getTargetQubits() const {
   return targetQubits;
 }
 
+void Assertion::setTargetQubits(std::vector<std::string> newTargetQubits) {
+  targetQubits = std::move(newTargetQubits);
+}
+
 EntanglementAssertion::EntanglementAssertion(
     std::vector<std::string> inputTargetQubits)
     : Assertion(std::move(inputTargetQubits), AssertionType::Entanglement) {}
@@ -35,11 +39,15 @@ EqualityAssertion::EqualityAssertion(double inputSimilarityThreshold,
                                      std::vector<std::string> inputTargetQubits,
                                      AssertionType assertionType)
     : Assertion(std::move(inputTargetQubits), assertionType),
-      similarityThreshold(inputSimilarityThreshold) {
+      similarityThreshold(inputSimilarityThreshold) {}
+
+void EqualityAssertion::validate() {
   if (similarityThreshold < 0 || similarityThreshold > 1) {
     throw ParsingError("Similarity threshold must be between 0 and 1");
   }
+  Assertion::validate();
 }
+
 double EqualityAssertion::getSimilarityThreshold() const {
   return similarityThreshold;
 }
@@ -49,12 +57,16 @@ StatevectorEqualityAssertion::StatevectorEqualityAssertion(
     std::vector<std::string> inputTargetQubits)
     : EqualityAssertion(inputSimilarityThreshold, std::move(inputTargetQubits),
                         AssertionType::StatevectorEquality),
-      targetStatevector(inputTargetStatevector) {
+      targetStatevector(inputTargetStatevector) {}
+
+void StatevectorEqualityAssertion::validate() {
   if (targetStatevector.numQubits != getTargetQubits().size()) {
     throw ParsingError(
         "Number of target qubits must match number of qubits in statevector");
   }
+  EqualityAssertion::validate();
 }
+
 const Statevector& StatevectorEqualityAssertion::getTargetStatevector() const {
   return targetStatevector;
 }

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -350,11 +350,25 @@ TEST_F(CustomCodeTest, RegisterInAssertion) {
 
 TEST_F(CustomCodeTest, RegisterInAssertionMixed) {
   loadCode(3, 0,
-           "qreg f[1], qreg p[2];"
+           "qreg f[1]; qreg p[2];"
            "x q[0]; x f[0]; x p[0];"
            "assert-eq q[0], f { 0, 0, 0, 1 }"
-           "assert-eq q[0], p { 0, 0, 0, 0, 1, 0, 0, 0 }"
-           "assert-eq f, p { 0, 0, 0, 0, 1, 0, 0, 0 }");
+           "assert-eq q[0], p { 0, 0, 0, 1, 0, 0, 0, 0 }"
+           "assert-eq f, p { 0, 0, 0, 1, 0, 0, 0, 0 }");
+  size_t errors = 0;
+  ASSERT_EQ(state->runAll(state, &errors), OK);
+  ASSERT_EQ(errors, 0);
+}
+
+TEST_F(CustomCodeTest, ShadowedRegisterInAssertionMixed) {
+  loadCode(3, 0,
+           "qreg f[1]; qreg p[2];"
+           "x q[0]; x f[0];"
+           "gate test q {"
+           "  x q;"
+           "  assert-eq q, f { 0, 0, 0, 1 }"
+           "}"
+           "test p[0];");
   size_t errors = 0;
   ASSERT_EQ(state->runAll(state, &errors), OK);
   ASSERT_EQ(errors, 0);

--- a/test/test_custom_code.cpp
+++ b/test/test_custom_code.cpp
@@ -337,6 +337,29 @@ TEST_F(CustomCodeTest, NonZeroControlsInErrorSearch) {
                                               errors.size()) == 0);
 }
 
+TEST_F(CustomCodeTest, RegisterInAssertion) {
+  loadCode(3, 0,
+           "h q[0]; cx q[0], q[1]; cx q[0], q[2];"
+           "assert-ent q;"
+           "assert-sup q;"
+           "assert-eq 0.9, q { 0.707, 0, 0, 0, 0, 0, 0, 0.707 }");
+  size_t errors = 0;
+  ASSERT_EQ(state->runAll(state, &errors), OK);
+  ASSERT_EQ(errors, 0);
+}
+
+TEST_F(CustomCodeTest, RegisterInAssertionMixed) {
+  loadCode(3, 0,
+           "qreg f[1], qreg p[2];"
+           "x q[0]; x f[0]; x p[0];"
+           "assert-eq q[0], f { 0, 0, 0, 1 }"
+           "assert-eq q[0], p { 0, 0, 0, 0, 1, 0, 0, 0 }"
+           "assert-eq f, p { 0, 0, 0, 0, 1, 0, 0, 0 }");
+  size_t errors = 0;
+  ASSERT_EQ(state->runAll(state, &errors), OK);
+  ASSERT_EQ(errors, 0);
+}
+
 TEST_F(CustomCodeTest, PaperExampleGrover) {
   loadCode(3, 3,
            "gate oracle q0, q1, q2, flag {"
@@ -355,10 +378,10 @@ TEST_F(CustomCodeTest, PaperExampleGrover) {
            "x flag;"
            "oracle q[0], q[1], q[2], flag;"
            "diffusion q[0], q[1], q[2];"
-           "assert-eq 0.8, q[0], q[1], q[2] { 0, 0, 0, 0, 0, 0, 0, 1 }"
+           "assert-eq 0.8, q { 0, 0, 0, 0, 0, 0, 0, 1 }"
            "oracle q[0], q[1], q[2], flag;"
            "diffusion q[0], q[1], q[2];"
-           "assert-eq 0.9, q[0], q[1], q[2] { 0, 0, 0, 0, 0, 0, 0, 1 }",
+           "assert-eq 0.9, q { 0, 0, 0, 0, 0, 0, 0, 1 }",
            false, "OPENQASM 2.0;\ninclude \"qelib1.inc\";\n");
 
   auto* diagnosis = state->getDiagnostics(state);

--- a/test/test_parsing.cpp
+++ b/test/test_parsing.cpp
@@ -51,15 +51,18 @@ TEST_F(ParsingTest, SuperpositionAssertion) {
 }
 
 TEST_F(ParsingTest, ErrorStatevectorEqualityAssertion) {
-  ASSERT_THROW(parseAssertion("assert-eq 1.5, q[0]", "1, 0"), ParsingError);
-  ASSERT_THROW(parseAssertion("assert-eq 0.5, q[0]", "1, 0, 0"), ParsingError);
-  ASSERT_THROW(parseAssertion("assert-eq 0.5, q[0]", "1, 0, 0, 0"),
+  ASSERT_THROW(parseAssertion("assert-eq 1.5, q[0]", "1, 0")->validate(),
+               ParsingError);
+  ASSERT_THROW(parseAssertion("assert-eq 0.5, q[0]", "1, 0, 0")->validate(),
+               ParsingError);
+  ASSERT_THROW(parseAssertion("assert-eq 0.5, q[0]", "1, 0, 0, 0")->validate(),
                ParsingError);
 }
 
 TEST_F(ParsingTest, ErrorCircuitEqualityAssertion) {
-  ASSERT_THROW(parseAssertion("assert-eq 1.5, q[0]", "qreg q[1]; h q[0];"),
-               ParsingError);
+  ASSERT_THROW(
+      parseAssertion("assert-eq 1.5, q[0]", "qreg q[1]; h q[0];")->validate(),
+      ParsingError);
 }
 
 TEST_F(ParsingTest, ErrorInvalidAssertion) {
@@ -83,10 +86,12 @@ TEST_F(ParsingTest, ComplexNumberParsing) {
 
 TEST_F(ParsingTest, ComplexNumberParsingErrorBadSimilarity) {
   // Similarity > 1
-  ASSERT_THROW(parseAssertion("assert-eq 2, q[0]", "1, 0"), ParsingError);
+  ASSERT_THROW(parseAssertion("assert-eq 2, q[0]", "1, 0")->validate(),
+               ParsingError);
 
   // Similarity out of double range
-  ASSERT_THROW(parseAssertion("assert-eq 1e500, q[0]", "1, 0"), ParsingError);
+  ASSERT_THROW(parseAssertion("assert-eq 1e500, q[0]", "1, 0")->validate(),
+               ParsingError);
 }
 
 TEST_F(ParsingTest, BadGateDefinition) {


### PR DESCRIPTION
## Description

This small PR adds support for register arguments in assertions. Now, instead of having to write

```
qreg q[3];
assert-eq q[0], q[1], q[2] { 1, 0, 0, 0, 0, 0, 0, 0 }
```

users can write

```
qreg q[3];
assert-eq q { 1, 0, 0, 0, 0, 0, 0, 0 }
```

Mixing and matching is also supported (e.g. `assert-eq q, psi[0]`).
This new format works for all types of assertions.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
